### PR TITLE
Replace deprecated non-bool mask in `masked_fill_`

### DIFF
--- a/src/model/lstm.py
+++ b/src/model/lstm.py
@@ -229,7 +229,7 @@ class LSTMModel(nn.Module):
 
         # add <EOS> to unfinished sentences
         if cur_len == max_len:
-            generated[-1].masked_fill_(unfinished_sents.byte(), self.eos_index)
+            generated[-1].masked_fill_(unfinished_sents.bool(), self.eos_index)
 
         # sanity check
         assert (generated == self.eos_index).sum() == 2 * bs

--- a/src/model/transformer.py
+++ b/src/model/transformer.py
@@ -711,7 +711,7 @@ class TransformerModel(nn.Module):
 
         # add <EOS> to unfinished sentences
         if cur_len == max_len:
-            generated[-1].masked_fill_(unfinished_sents.byte(), self.eos_index)
+            generated[-1].masked_fill_(unfinished_sents.bool(), self.eos_index)
 
         # sanity check
         assert (generated == self.eos_index).sum() == 2 * bs


### PR DESCRIPTION
pytorch/pytorch#96594 deprecated non-bool mask in `masked_fill`.
fixed all `masked_fill_` call

Closes #4 