### PR TITLE
Fix PyTorch warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# Dump directory for prototyping and testing purposes
+dump/
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/src/model/lstm.py
+++ b/src/model/lstm.py
@@ -229,7 +229,7 @@ class LSTMModel(nn.Module):
 
         # add <EOS> to unfinished sentences
         if cur_len == max_len:
-            generated[-1].masked_fill_(unfinished_sents.byte(), self.eos_index)
+            generated[-1].masked_fill_(unfinished_sents.bool(), self.eos_index)
 
         # sanity check
         assert (generated == self.eos_index).sum() == 2 * bs

--- a/src/model/transformer.py
+++ b/src/model/transformer.py
@@ -711,7 +711,7 @@ class TransformerModel(nn.Module):
 
         # add <EOS> to unfinished sentences
         if cur_len == max_len:
-            generated[-1].masked_fill_(unfinished_sents.byte(), self.eos_index)
+            generated[-1].masked_fill_(unfinished_sents.bool(), self.eos_index)
 
         # sanity check
         assert (generated == self.eos_index).sum() == 2 * bs

--- a/src/optim.py
+++ b/src/optim.py
@@ -74,8 +74,8 @@ class Adam(optim.Optimizer):
                 #     grad.add_(group['weight_decay'], p.data)
 
                 # Decay the first and second moment running average coefficient
-                exp_avg.mul_(beta1).add_(1 - beta1, grad)
-                exp_avg_sq.mul_(beta2).addcmul_(1 - beta2, grad, grad)
+                exp_avg.mul_(beta1).add_(grad, alpha=1 - beta1)
+                exp_avg_sq.mul_(beta2).addcmul_(grad, grad, value=1 - beta2)
                 denom = exp_avg_sq.sqrt().add_(group['eps'])
                 # denom = exp_avg_sq.sqrt().clamp_(min=group['eps'])
 
@@ -84,9 +84,9 @@ class Adam(optim.Optimizer):
                 step_size = group['lr'] * math.sqrt(bias_correction2) / bias_correction1
 
                 if group['weight_decay'] != 0:
-                    p.data.add_(-group['weight_decay'] * group['lr'], p.data)
+                    p.data.add_(p.data, alpha=-group['weight_decay'] * group['lr'])
 
-                p.data.addcdiv_(-step_size, exp_avg, denom)
+                p.data.addcdiv_(exp_avg, denom, value=-step_size)
 
         return loss
 


### PR DESCRIPTION
### Summary

This PR resolves several `UserWarning` messages from PyTorch by 

- updating deprecated function calls in the custom Adam optimizer located in `src/optim.py`.
- updating function calls in `src/model/transformer.py` and `src/model/lstm.py`.
- updating `.gitignore` to include a `dump` directory for saving temporary training files.

This is a non-functional change that ensures forward compatibility with future PyTorch versions and cleans up the logs.

### Changes

The following deprecated function signatures were updated:

* `add_(Number, Tensor)` is now `add_(Tensor, *, alpha=Number)`
* `addcmul_(Number, Tensor, Tensor)` is now `addcmul_(Tensor, Tensor, *, value=Number)`
* `addcdiv_(Number, Tensor, Tensor)` is now `addcdiv_(Tensor, Tensor, *, value=Number)`
* replace `.byte()` with `.bool()` in masking
* Added `dump` directory to `.gitignore`

**Example:**

**Before:**
- `p.data.addcdiv_(-step_size, exp_avg, denom)`
- `generated[-1].masked_fill_(unfinished_sents.byte(), self.eos_index)`

**After:**
- `p.data.addcdiv_(exp_avg, denom, value=-step_size)`
- `generated[-1].masked_fill_(unfinished_sents.bool(), self.eos_index)`

### Context

This change is motivated by an API evolution in PyTorch, as discussed in the official PyTorch repository.

* **Related GitHub Issue:** [pytorch/pytorch#32861](https://github.com/pytorch/pytorch/issues/32861)
* **PyTorch Discussions** [overload of add_ , addcmul_, addcdiv_ is deprecated](https://discuss.pytorch.org/t/userwarning-this-overload-of-add-addcmul-addcdiv-is-deprecated-errors-while-implementing-sharedadam/99802)
*  and [dtype torch.uint8 is now deprecated](https://discuss.pytorch.org/t/userwarning-indexing-with-dtype-torch-uint8-is-now-deprecated-please-use-dtype-torch-bool-instead/82155)